### PR TITLE
go mod updates and npm install typescript fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/doomsday-project/doomsday
 
-go 1.21.6
+go 1.22
 
 toolchain go1.22.4
 


### PR DESCRIPTION
The go mod tidy command made things with 1.22 so decided to go with that style.   Yes, it forces people to use 1.22 but that is not bad thing.

The Makefile lines for tsc build did not account for each make line being run independently when those lines were dependent on the cd web line.
